### PR TITLE
fix: 키워드를 불러오지 못하고 스케줄 넘버를 불러오는 현상 해결

### DIFF
--- a/frontend/src/views/client/ClientScheduleDetailView.vue
+++ b/frontend/src/views/client/ClientScheduleDetailView.vue
@@ -13,7 +13,8 @@ const hourHeight = 60
 const timeLabelWidth = 80
 const colors = [
   '#69a8ff', '#20c997', '#ffc107', '#e07777',
-  '#9b7bcc', '#fca344', '#a3a7ff','#8fd565']
+  '#9b7bcc', '#fca344', '#a3a7ff','#8fd565'
+]
 
 onMounted(async () => {
   try {
@@ -45,12 +46,19 @@ function arrangeSchedulePositions(scheduleList) {
 const goToSchedule = (scheduleNo) => {
   router.push(`/client/broadcasts/schedule/${scheduleNo}/preQuestion`)
 }
+
+const goBackToCalendar = () => {
+  router.push('/client/broadcasts/schedule')
+}
 </script>
 
 <template>
   <ClientFrame>
     <div class="w-100 min-vh-100 px-4 py-4">
-      <h2 class="fs-3 fw-bold text-primary mb-4">📅 {{ dateStr }} 방송 스케줄</h2>
+      <div class="d-flex justify-content-between align-items-center mb-4">
+        <h2 class="fs-3 fw-bold text-primary mb-0">📅 {{ dateStr }} 방송 스케줄</h2>
+        <button class="btn btn-outline-secondary" @click="goBackToCalendar">← 달력으로 돌아가기</button>
+      </div>
 
       <div class="timeline-wrapper border rounded overflow-auto position-relative">
         <div class="timeline-inner" style="min-width: 1200px;">
@@ -75,7 +83,7 @@ const goToSchedule = (scheduleNo) => {
                   :style="{ backgroundColor: schedule.color }"
                   @click="goToSchedule(schedule.no)"
               >
-                <div class="fw-semibold text-truncate">▶ {{ schedule.name }}</div>
+                <div class="fw-semibold text-truncate">📺 {{ schedule.name }}</div>
                 <div class="small text-black-50">{{ schedule.lawyerName }} 변호사</div>
                 <div class="small">🕒 {{ schedule.startTime.slice(11, 16) }} ~ {{ schedule.endTime.slice(11, 16) }}</div>
                 <div class="small schedule-content">{{ schedule.content }}</div>
@@ -109,7 +117,7 @@ const goToSchedule = (scheduleNo) => {
   cursor: pointer;
   width: 250px;
   min-height: 60px;
-  margin-top: 4px; /* 살짝 위아래 간격 추가 */
+  margin-top: 4px;
   margin-bottom: 4px;
   transition: transform 0.1s ease, box-shadow 0.1s ease;
   overflow: hidden;

--- a/frontend/src/views/client/ClientScheduleView.vue
+++ b/frontend/src/views/client/ClientScheduleView.vue
@@ -11,6 +11,8 @@ const router = useRouter()
 const calendarRef = ref(null)
 const events = ref([])
 
+const colors = ['#ebfde8', '#fff9d6', '#d6eeff', '#ffdfdf', '#eee4ff', '#fdead6']
+
 const calendarOptions = ref({
   plugins: [dayGridPlugin, interactionPlugin],
   initialView: 'dayGridMonth',
@@ -41,20 +43,16 @@ const calendarOptions = ref({
     const startTime = new Date(original.startTime)
     const endTime = original.endTime ? new Date(original.endTime) : null
 
-    const startDate = startTime.toISOString().slice(0, 10)
     const startHour = String(startTime.getHours()).padStart(2, '0')
     const startMin = String(startTime.getMinutes()).padStart(2, '0')
     const startStr = `${startHour}:${startMin}`
 
     let timeRange = `[${startStr}`
     if (endTime) {
-      const endDate = endTime.toISOString().slice(0, 10)
-      if (startDate === endDate) {
-        const endHour = String(endTime.getHours()).padStart(2, '0')
-        const endMin = String(endTime.getMinutes()).padStart(2, '0')
-        const endStr = `${endHour}:${endMin}`
-        timeRange += ` ~ ${endStr}`
-      }
+      const endHour = String(endTime.getHours()).padStart(2, '0')
+      const endMin = String(endTime.getMinutes()).padStart(2, '0')
+      const endStr = `${endHour}:${endMin}`
+      timeRange += ` ~ ${endStr}`
     }
     timeRange += `]`
 
@@ -77,11 +75,14 @@ const fetchMonthlySchedule = async () => {
     const now = new Date()
     const month = now.toISOString().slice(0, 7)
     const res = await axios.get(`/api/schedule/month?month=${month}`)
-    events.value = res.data.map(ev => {
+    events.value = res.data.map((ev, index) => {
       const startDateOnly = ev.startTime.slice(0, 10)
       return {
         title: ev.title,
         start: startDateOnly,
+        backgroundColor: colors[index % colors.length],
+        borderColor: '#dee2e6',
+        textColor: '#212529',
         extendedProps: {
           lawyerName: ev.lawyerName,
           original: ev
@@ -144,11 +145,8 @@ onMounted(fetchMonthlySchedule)
 }
 ::v-deep(.fc-event) {
   max-width: 100% !important;
-  overflow: hidden;
   border-radius: 0.25rem;
   padding: 2px 4px;
-  background-color: #ffffff;
-  border: 1px solid #dee2e6;
   transition: background-color 0.15s;
 }
 ::v-deep(.fc-event:hover) {
@@ -172,5 +170,12 @@ onMounted(fetchMonthlySchedule)
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
+}
+::v-deep(.fc-day-past) {
+  background-color: #ebedef;
+  opacity: 0.6;
+}
+::v-deep(.fc-day-past .fc-event) {
+  opacity: 0.5;
 }
 </style>

--- a/frontend/src/views/lawyer/LawyerScheduleDetailView.vue
+++ b/frontend/src/views/lawyer/LawyerScheduleDetailView.vue
@@ -76,7 +76,28 @@ const handleFileChange = (e) => {
   }
 }
 
+const goBack = () => {
+  router.push('/lawyer/broadcasts/schedule')
+}
+
+const deleteSchedule = async () => {
+  const confirmDelete = confirm('❗ 정말 이 방송 스케줄을 삭제하시겠습니까?')
+  if (!confirmDelete) return
+
+  try {
+    await axios.delete(`/api/schedule/delete/${scheduleNo}`)
+    alert('🗑️ 방송 스케줄이 삭제되었습니다.')
+    router.push('/lawyer/broadcasts/schedule')
+  } catch (err) {
+    alert('⚠️ 삭제 실패')
+    console.error(err)
+  }
+}
+
 const updateSchedule = async () => {
+  const confirmUpdate = confirm('✏️ 방송 스케줄을 수정하시겠습니까?')
+  if (!confirmUpdate) return
+
   try {
     const form = new FormData()
     form.append('scheduleNo', scheduleNo)
@@ -175,8 +196,14 @@ const updateSchedule = async () => {
             </div>
           </div>
         </div>
-        <div class="d-flex justify-content-end">
-          <button class="btn btn-primary" @click="updateSchedule">수정</button>
+
+        <!-- 버튼 영역 -->
+        <div class="d-flex justify-content-between mt-4">
+          <button class="btn btn-secondary" @click="goBack">← 목록으로</button>
+          <div class="d-flex gap-2">
+            <button class="btn btn-danger" @click="deleteSchedule">삭제</button>
+            <button class="btn btn-primary" @click="updateSchedule">수정</button>
+          </div>
         </div>
       </div>
     </div>

--- a/frontend/src/views/lawyer/LawyerScheduleRegisterView.vue
+++ b/frontend/src/views/lawyer/LawyerScheduleRegisterView.vue
@@ -132,6 +132,10 @@ const submitSchedule = async () => {
     alert('⚠️ 등록 중 오류 발생')
   }
 }
+
+const goBack = () => {
+  router.push('/lawyer/broadcasts/schedule')
+}
 </script>
 
 <template>
@@ -216,7 +220,8 @@ const submitSchedule = async () => {
           </div>
         </div>
 
-        <div class="d-flex justify-content-end">
+        <div class="d-flex justify-content-between mt-4">
+          <button class="btn btn-outline-secondary" @click="goBack">← 목록으로</button>
           <button class="btn btn-primary" @click="submitSchedule">등록</button>
         </div>
       </div>

--- a/frontend/src/views/lawyer/LawyerScheduleView.vue
+++ b/frontend/src/views/lawyer/LawyerScheduleView.vue
@@ -11,13 +11,21 @@ const router = useRouter()
 const fetchSchedules = async () => {
   try {
     const res = await axios.get('/api/schedule/my')
-    schedules.value = res.data
-    groupedSchedules.value = groupByDate(res.data)
+    const futureSchedules = filterFutureSchedules(res.data)
+    schedules.value = futureSchedules
+    groupedSchedules.value = groupByDate(futureSchedules)
   } catch (err) {
     console.error('방송 스케줄 로딩 실패:', err)
   }
 }
 
+// 현재 시간 이후인 스케줄만 필터링
+const filterFutureSchedules = (items) => {
+  const now = new Date()
+  return items.filter(item => new Date(item.endTime) > now)
+}
+
+// 날짜별로 스케줄 그룹핑
 const groupByDate = (items) => {
   return items.reduce((acc, item) => {
     const date = item.date
@@ -48,7 +56,9 @@ onMounted(fetchSchedules)
         <button class="btn btn-outline-primary" @click="goToRegister">➕ 새 스케줄 등록</button>
       </div>
 
-      <div v-if="Object.keys(groupedSchedules).length === 0" class="text-muted">방송 스케줄이 없습니다.</div>
+      <div v-if="Object.keys(groupedSchedules).length === 0" class="text-muted">
+        방송 스케줄이 없습니다.
+      </div>
 
       <div v-for="(list, date) in groupedSchedules" :key="date" class="mb-5">
         <h4 class="mb-3 fw-semibold border-bottom pb-2">📆 {{ date }}</h4>

--- a/src/main/java/com/lawnroad/broadcast/live/controller/ScheduleController.java
+++ b/src/main/java/com/lawnroad/broadcast/live/controller/ScheduleController.java
@@ -7,6 +7,7 @@ import com.lawnroad.broadcast.live.dto.*;
 import com.lawnroad.broadcast.live.service.ScheduleService;
 import com.lawnroad.common.util.FileStorageUtil;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
@@ -139,4 +140,13 @@ public class ScheduleController {
         return ResponseEntity.ok("스케줄이 성공적으로 수정되었습니다.");
     }
 
+    @DeleteMapping("/delete/{scheduleNo}")
+    public ResponseEntity<String> deleteSchedule(@PathVariable Long scheduleNo) {
+        int deletedCount = scheduleService.deleteScheduleByNo(scheduleNo);
+        if (deletedCount == 0) {
+            return ResponseEntity.status(HttpStatus.NOT_FOUND)
+                    .body("삭제할 스케줄이 존재하지 않습니다.");
+        }
+        return ResponseEntity.ok("삭제 완료");
+    }
 }

--- a/src/main/java/com/lawnroad/broadcast/live/mapper/ScheduleMapper.java
+++ b/src/main/java/com/lawnroad/broadcast/live/mapper/ScheduleMapper.java
@@ -18,4 +18,5 @@ public interface ScheduleMapper {
     ScheduleDetailDto findByScheduleNo(@Param("scheduleNo") Long scheduleNo);
 
     void updateSchedule(ScheduleUpdateDto scheduleUpdateDto);
+    int deleteScheduleByNo(Long scheduleNo);
 }

--- a/src/main/java/com/lawnroad/broadcast/live/service/ScheduleService.java
+++ b/src/main/java/com/lawnroad/broadcast/live/service/ScheduleService.java
@@ -13,4 +13,5 @@ public interface ScheduleService {
     List<ScheduleResponseDto> getSchedulesByLawyer(Long userNo);
     ScheduleDetailDto findDetailByScheduleNo(Long scheduleNo);
     void updateSchedule(ScheduleUpdateDto scheduleUpdateDto);
+    int deleteScheduleByNo(Long scheduleNo);
 }

--- a/src/main/java/com/lawnroad/broadcast/live/service/ScheduleServiceImpl.java
+++ b/src/main/java/com/lawnroad/broadcast/live/service/ScheduleServiceImpl.java
@@ -85,4 +85,9 @@ public class ScheduleServiceImpl implements ScheduleService {
             }
         }
     }
+
+    @Override
+    public int deleteScheduleByNo(Long scheduleNo) {
+        return scheduleMapper.deleteScheduleByNo(scheduleNo);
+    }
 }

--- a/src/main/resources/mapper/ScheduleMapper.xml
+++ b/src/main/resources/mapper/ScheduleMapper.xml
@@ -91,7 +91,6 @@
         JOIN category c ON bs.category_no = c.no
         WHERE bs.no = #{scheduleNo}
     </select>
-
     <!-- 키워드 리스트를 별도로 조회하는 select -->
     <select id="findKeywordsByScheduleNo" resultType="String">
         SELECT keyword FROM keyword WHERE schedule_no = #{schedule_no}
@@ -106,5 +105,11 @@
         thumbnail_path = #{thumbnailPath}
         WHERE no = #{scheduleNo}
     </update>
+
+    <!-- 방송 스케줄 삭제 -->
+    <delete id="deleteScheduleByNo" parameterType="long">
+        DELETE FROM broadcast_schedule
+        WHERE no = #{scheduleNo}
+    </delete>
 
 </mapper>

--- a/src/main/resources/mapper/ScheduleMapper.xml
+++ b/src/main/resources/mapper/ScheduleMapper.xml
@@ -17,8 +17,10 @@
         <result property="endTime" column="end_time"/>
         <result property="categoryName" column="category_name"/>
 
-        <!-- 키워드 리스트 매핑 -->
-        <collection property="keywords" ofType="String" column="keyword"/>
+        <!-- 키워드 리스트 매핑 (서브쿼리 사용) -->
+        <collection property="keywords" ofType="String"
+                    column="schedule_no"
+                    select="findKeywordsByScheduleNo"/>
     </resultMap>
 
     <insert id="insertSchedule" parameterType="com.lawnroad.broadcast.live.model.ScheduleVo" useGeneratedKeys="true" keyProperty="no">
@@ -75,8 +77,7 @@
     </select>
 
     <select id="findByScheduleNo" resultMap="ScheduleDetailMap">
-        SELECT
-        bs.no AS schedule_no,
+        SELECT bs.no AS schedule_no,
         bs.user_no,
         bs.category_no,
         bs.name,
@@ -85,12 +86,15 @@
         bs.date,
         bs.start_time,
         bs.end_time,
-        c.name AS category_name,
-        k.keyword AS keyword
+        c.name AS category_name
         FROM broadcast_schedule bs
         JOIN category c ON bs.category_no = c.no
-        LEFT JOIN keyword k ON k.schedule_no = bs.no
         WHERE bs.no = #{scheduleNo}
+    </select>
+
+    <!-- 키워드 리스트를 별도로 조회하는 select -->
+    <select id="findKeywordsByScheduleNo" resultType="String">
+        SELECT keyword FROM keyword WHERE schedule_no = #{schedule_no}
     </select>
 
     <update id="updateSchedule" parameterType="com.lawnroad.broadcast.live.dto.ScheduleUpdateDto">


### PR DESCRIPTION
## 작업 내용

- [x] 키워드를 서브쿼리로 변경하여, `키워드를 불러오지 못하고 스케줄 넘버를 불러오는 현상` 해결
- [x] 변호사 등록한 스케줄 보기 -> 현재 날짜 이후의 스케줄만 보이도록 수정
- [x] 클라이언트 월별 스케줄 캘린더 -> 오늘 이전의 내용은 어둡게 변경, 각 스케줄 카드 색상 수정
- [x] 각 페이지에 뒤로가기 버튼 추가

## 전달사항

-

---

## PR 체크리스트

- [x] 커밋 메시지를 컨벤션에 맞게 작성했나요?
- [x] 로컬에서 테스트를 완료했나요?
- [x] 작업 전에 dev를 pull 받고 작업했나요?
- [x] push 하기 전에 dev를 작업 브랜치로 merge 받았나요?
- [x] dev 브랜치로 PR 올리는 중인지 다시 확인했나요?
- [x] PR 제목을 `feat: 작업내용 한줄 요약` 으로 올렸나요?