### PR TITLE
fix: 테이블 수정 및 로그인에 대한 에러 수정

### DIFF
--- a/frontend/src/views/client/template/TmplHistoryListView.vue
+++ b/frontend/src/views/client/template/TmplHistoryListView.vue
@@ -24,6 +24,7 @@ const isDownloaded = ref(false)
 async function fetchOrders(page = 1, query = {}) {
   const params = { page, limit: 10, ...query }
   const res = await http.get('/api/client/templates/orders', params)
+  console.log(res)
 
   rows.value = res.data.orders
   totalPages.value = res.data.totalPages
@@ -69,7 +70,7 @@ onMounted(() => fetchOrders())
             },
             {
               label: '총금액',
-              key: 'totalAmount',
+              key: 'amount',
               formatter: (v) => `${v.toLocaleString()}원`
             },
             {

--- a/frontend/src/views/common/LoginView.vue
+++ b/frontend/src/views/common/LoginView.vue
@@ -98,21 +98,40 @@ const submitLogin = async () => {
     }
   }
 }
+
 function parseJwt(token) {
   try {
-    const base64 = token.split('.')[1]
-    const json = decodeURIComponent(
-        atob(base64)
-            .split('')
-            .map((c) => '%' + c.charCodeAt(0).toString(16).padStart(2, '0'))
-            .join('')
-    )
+    let base64 = token.split('.')[1]
+    // base64url → base64 변환
+    base64 = base64.replace(/-/g, '+').replace(/_/g, '/')
+    // 패딩 추가 (길이가 4의 배수가 되도록)
+    while (base64.length % 4 !== 0) {
+      base64 += '='
+    }
+
+    const json = atob(base64)
     return JSON.parse(json)
   } catch (e) {
     console.error('❌ JWT 파싱 실패:', e)
     return null
   }
 }
+
+// function parseJwt(token) {
+//   try {
+//     const base64 = token.split('.')[1]
+//     const json = decodeURIComponent(
+//         atob(base64)
+//             .split('')
+//             .map((c) => '%' + c.charCodeAt(0).toString(16).padStart(2, '0'))
+//             .join('')
+//     )
+//     return JSON.parse(json)
+//   } catch (e) {
+//     console.error('❌ JWT 파싱 실패:', e)
+//     return null
+//   }
+// }
 
 </script>
 

--- a/src/main/java/com/lawnroad/template/controller/ClientTemplateController.java
+++ b/src/main/java/com/lawnroad/template/controller/ClientTemplateController.java
@@ -37,6 +37,8 @@ public class ClientTemplateController {
     List<ClientOrderListDto> list = clientTemplateService.findOrders(userNo, status, page, limit);
     int totalCount = clientTemplateService.countOrders(userNo, status);
     
+    // System.out.println(list);
+    
     // 총 페이지 계산
     int totalPages = (int) Math.ceil((double) totalCount / limit);
     

--- a/src/main/java/com/lawnroad/template/dto/order/ClientOrderListDto.java
+++ b/src/main/java/com/lawnroad/template/dto/order/ClientOrderListDto.java
@@ -5,11 +5,12 @@ import lombok.Data;
 @Data
 public class ClientOrderListDto {
   private Long orderNo;
-  private String status;         // ORDERED, PAID, CANCELED
-  private String orderDate;      // 주문일자 (yyyy-MM-dd)
-  private Long totalAmount;      // 총 결제 금액
+  private String orderCode; // 랜덤값
+  private String status; // ORDERED, PAID, CANCELED
+  private String orderDate; // 주문일자 (yyyy-MM-dd)
+  private Long amount; // 총 결제 금액
   
-  private String firstTemplateName;  // 대표 템플릿명
-  private int templateCount;         // 전체 상품 수
+  private String firstTemplateName; // 대표 템플릿명
+  private int templateCount; // 전체 상품 수
   private int isDownloaded;
 }

--- a/src/main/java/com/lawnroad/template/service/CartServiceImpl.java
+++ b/src/main/java/com/lawnroad/template/service/CartServiceImpl.java
@@ -10,6 +10,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
+import java.util.UUID;
 
 @Service
 @RequiredArgsConstructor
@@ -61,6 +62,7 @@ public class CartServiceImpl implements CartService {
     // ③ 주문 생성
     OrdersCreateDTO orderDto = new OrdersCreateDTO();
     orderDto.setUserNo(dto.getUserNo());
+    orderDto.setOrderCode(UUID.randomUUID().toString());
     orderDto.setAmount((long) totalAmount);
     orderDto.setStatus("ORDERED");
     orderDto.setOrderType("TEMPLATE");

--- a/src/main/resources/mapper/ClientTemplateMapper.xml
+++ b/src/main/resources/mapper/ClientTemplateMapper.xml
@@ -97,9 +97,11 @@
         SELECT
         o.no AS order_no,
         o.status,
+        o.order_code AS orderCode,
         DATE_FORMAT(o.created_at, '%Y-%m-%d') AS order_date,
-        o.total_amount,
+        o.amount,
 
+        -- 대표 템플릿명 가져오기 (서브쿼리)
         -- 대표 템플릿명 가져오기 (서브쿼리)
         (SELECT t.name
         FROM tmpl_orders_history toh


### PR DESCRIPTION
## 작업 내용

- [ ] jwt 파싱 문제 인코딩 해결
- [ ] 결제하기 수정
- [ ] 상품 조회 수정

## 전달사항

- orders 테이블에 대해 아래 코드 진행

```
-- 1. 임시로 NULL 허용하고 컬럼 추가
ALTER TABLE orders
    ADD COLUMN order_code VARCHAR(64);

-- 2. 기존 행에 고유한 값 채우기 (예시: UUID 또는 일련번호 사용)
-- 예: UUID 사용 (MySQL 8.0 이상)
UPDATE orders
SET order_code = UUID()
WHERE order_code IS NULL;

-- 3. NOT NULL + UNIQUE 제약 조건 추가
ALTER TABLE orders
    MODIFY COLUMN order_code VARCHAR(64) NOT NULL UNIQUE;

-- 4. total_amount 컬럼 이름 변경 → amount
ALTER TABLE orders
    CHANGE COLUMN total_amount amount INT;
```
---

## PR 체크리스트

- [ ] 커밋 메시지를 컨벤션에 맞게 작성했나요?
- [ ] 로컬에서 테스트를 완료했나요?
- [ ] 작업 전에 dev를 pull 받고 작업했나요?
- [ ] push 하기 전에 dev를 작업 브랜치로 merge 받았나요?
- [ ] dev 브랜치로 PR 올리는 중인지 다시 확인했나요?
- [ ] PR 제목을 `feat: 작업내용 한줄 요약` 으로 올렸나요?