### PR TITLE
refactor: 방송 종료 자동처리기능 / 방송중인 스케줄 클릭시 방송으로 이동

### DIFF
--- a/frontend/src/libs/axios-auth.js
+++ b/frontend/src/libs/axios-auth.js
@@ -52,30 +52,6 @@ export const refreshAccessToken = async () => {
     }
 }
 
-export const getValidToken = async () => {
-    let token = localStorage.getItem('token')
-    let expired = false
-
-    if (token) {
-        try {
-            const decoded = jwt_decode(token)
-            const now = Math.floor(Date.now() / 1000)
-            // 60초 이내 만료될 예정이면 미리 갱신
-            if (decoded.exp && decoded.exp - now < 60) expired = true
-        } catch {
-            expired = true
-        }
-    } else {
-        expired = true
-    }
-
-    if (expired) {
-        token = await refreshAccessToken()
-        if (!token) return null
-    }
-    return token
-}
-
 export const makeApiRequest = async (config) => {
     let token = localStorage.getItem('token')
     if (!token) {

--- a/frontend/src/views/client/ClientBroadcastListView.vue
+++ b/frontend/src/views/client/ClientBroadcastListView.vue
@@ -37,8 +37,17 @@ const formatStartTime = (isoString) => {
   return `${MM}-${DD} ${hh}:${mm} 방송시작`
 }
 
-onMounted(() => {
-  fetchLiveBroadcasts()
+onMounted(async () => {
+  try {
+    await makeApiRequest({
+      method: 'get',
+      url: '/api/client/broadcast/expire-overdue'
+    })
+    console.log('⏱ 방송 상태 갱신 완료')
+  } catch (err) {
+    console.warn('방송 만료 처리 실패:', err)
+  }
+  await fetchLiveBroadcasts()
 })
 </script>
 

--- a/frontend/src/views/client/ClientScheduleView.vue
+++ b/frontend/src/views/client/ClientScheduleView.vue
@@ -123,7 +123,21 @@ const fetchMonthlySchedule = async () => {
 }
 
 
-onMounted(fetchMonthlySchedule)
+onMounted(async () => {
+  try {
+    // 방송 종료 상태 갱신 먼저 수행
+    await makeApiRequest({
+      method: 'get',
+      url: '/api/client/broadcast/expire-overdue'
+    })
+    console.log('⏱ 방송 상태 갱신 완료')
+  } catch (err) {
+    console.warn('방송 만료 처리 실패:', err)
+  }
+
+  // 갱신 후 스케줄 목록 불러오기
+  await fetchMonthlySchedule()
+})
 </script>
 
 <template>

--- a/frontend/src/views/client/ClientScheduleView.vue
+++ b/frontend/src/views/client/ClientScheduleView.vue
@@ -58,15 +58,17 @@ const calendarOptions = ref({
     timeRange += `]`
 
     const lawyer = original.lawyerName || ''
+    const isLive = info.event.extendedProps.isLive === true
     const tooltip = `${timeRange} ${title} (${lawyer} 변호사)`
 
     return {
       html: `
-        <div title="${tooltip}" class="fc-custom-event">
-          <div class="fc-event-title text-dark fw-semibold">${title}</div>
-          <div class="fc-lawyer-name text-muted small">${lawyer} 변호사</div>
-        </div>
-      `
+    <div title="${tooltip}" class="fc-custom-event">
+      ${isLive ? '<div class="live-badge">LIVE</div>' : ''}
+      <div class="fc-event-title text-dark fw-semibold">${title}</div>
+      <div class="fc-lawyer-name text-muted small">${lawyer} 변호사</div>
+    </div>
+  `
     }
   }
 })
@@ -82,7 +84,22 @@ const fetchMonthlySchedule = async () => {
     })
 
     if (res?.data) {
-      events.value = res.data.map((ev, index) => {
+      const checkLiveList = await Promise.all(
+          res.data.map(ev =>
+              makeApiRequest({
+                method: 'get',
+                url: `/api/client/broadcast/live-check/${ev.scheduleNo}`
+              }).then(liveRes => ({
+                ...ev,
+                isLive: liveRes.data.live
+              })).catch(() => ({
+                ...ev,
+                isLive: false
+              }))
+          )
+      )
+      console.log("✅ 이벤트 리스트", events.value)
+      events.value = checkLiveList.map((ev, index) => {
         const startDateOnly = ev.startTime.slice(0, 10)
         return {
           title: ev.title,
@@ -92,6 +109,7 @@ const fetchMonthlySchedule = async () => {
           textColor: '#212529',
           extendedProps: {
             lawyerName: ev.lawyerName,
+            isLive: ev.isLive,
             original: ev
           }
         }
@@ -187,5 +205,19 @@ onMounted(fetchMonthlySchedule)
 }
 ::v-deep(.fc-day-past .fc-event) {
   opacity: 0.5;
+}
+::v-deep(.live-badge) {
+  position: absolute;
+  top: 1px;
+  right: 1px;
+  background-color: #dc3545;
+  color: white;
+  font-size: 7px;
+  font-weight: bold;
+  padding: 2px 5px;
+  border-radius: 4px;
+  letter-spacing: 0.5px;
+  box-shadow: 0 0 4px rgba(0, 0, 0, 0.2);
+  z-index: 1;
 }
 </style>

--- a/frontend/src/views/lawyer/LawyerScheduleView.vue
+++ b/frontend/src/views/lawyer/LawyerScheduleView.vue
@@ -43,8 +43,26 @@ const groupByDate = (items) => {
   }, {})
 }
 
+const isBroadcastReady = (startTime) => {
+  const now = new Date()
+  const start = new Date(startTime)
+  const tenMinutesBeforeStart = new Date(start.getTime() - 10 * 60 * 1000)
+  return now >= tenMinutesBeforeStart
+}
+
 const goToDetail = (scheduleNo) => {
-  if (scheduleNo) {
+  const schedule = schedules.value.find(s => s.scheduleNo === scheduleNo)
+  if (!schedule) return
+
+  const now = new Date()
+  const start = new Date(schedule.startTime)
+  const tenMinutesBeforeStart = new Date(start.getTime() - 10 * 60 * 1000)
+
+  if (now >= tenMinutesBeforeStart) {
+    // 방송 시작 10분 전 이후면 → 방송 세팅 페이지로 이동
+    router.push({ name: 'LawyerBroadcastSetting', params: { scheduleNo } })
+  } else {
+    // 그 전이면 → 일반 상세 페이지로 이동
     router.push({ name: 'LawyerBroadcastsScheduleDetail', params: { scheduleNo } })
   }
 }
@@ -84,6 +102,11 @@ onMounted(fetchSchedules)
             <div class="text-primary fw-semibold">
               🕒 {{ schedule.startTime.slice(11, 16) }} ~ {{ schedule.endTime.slice(11, 16) }}
               <span class="badge bg-secondary ms-2">{{ schedule.categoryName }}</span>
+              <!-- 방송 시작 가능 여부에 따라 배지 표시 -->
+              <span
+                  v-if="isBroadcastReady(schedule.startTime)"
+                  class="badge bg-danger ms-2"
+              >방송 시작 가능</span>
             </div>
           </div>
           <h5 class="fw-bold mb-1 text-dark">{{ schedule.title }}</h5>

--- a/src/main/java/com/lawnroad/broadcast/live/controller/BroadcastClientController.java
+++ b/src/main/java/com/lawnroad/broadcast/live/controller/BroadcastClientController.java
@@ -77,4 +77,9 @@ public class BroadcastClientController {
             return ResponseEntity.ok(Map.of("live", false));
         }
     }
+
+    @GetMapping("/expire-overdue")
+    public void expireOverdueBroadcasts() {
+        broadcastService.expireOverdueBroadcasts();
+    }
 }

--- a/src/main/java/com/lawnroad/broadcast/live/controller/BroadcastClientController.java
+++ b/src/main/java/com/lawnroad/broadcast/live/controller/BroadcastClientController.java
@@ -10,6 +10,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
+import java.util.Map;
 
 @RestController
 @RequestMapping("/api/client/broadcast")
@@ -61,5 +62,19 @@ public class BroadcastClientController {
     public ResponseEntity<List<BroadcastListDto>> getLiveBroadcasts() {
         List<BroadcastListDto> liveList = broadcastService.getLiveBroadcasts();
         return ResponseEntity.ok(liveList);
+    }
+    // 라이브 중인지 확인
+    @GetMapping("/live-check/{scheduleNo}")
+    public ResponseEntity<Map<String, Object>> checkLiveBroadcast(@PathVariable Long scheduleNo) {
+        Long broadcastNo = broadcastService.findLiveBroadcastNoByScheduleNo(scheduleNo);
+
+        if (broadcastNo != null) {
+            return ResponseEntity.ok(Map.of(
+                    "live", true,
+                    "broadcastNo", broadcastNo
+            ));
+        } else {
+            return ResponseEntity.ok(Map.of("live", false));
+        }
     }
 }

--- a/src/main/java/com/lawnroad/broadcast/live/mapper/BroadcastMapper.java
+++ b/src/main/java/com/lawnroad/broadcast/live/mapper/BroadcastMapper.java
@@ -29,4 +29,6 @@ public interface BroadcastMapper {
     List<BroadcastListDto> selectLiveBroadcasts();
     // 세션ID 가져오기
     String findSessionIdByBroadcastNo(Long broadcastNo);
+    // 해당 스케줄이 방송중인지
+    Long findLiveBroadcastNoByScheduleNo(Long scheduleNo);
 }

--- a/src/main/java/com/lawnroad/broadcast/live/mapper/BroadcastMapper.java
+++ b/src/main/java/com/lawnroad/broadcast/live/mapper/BroadcastMapper.java
@@ -31,4 +31,6 @@ public interface BroadcastMapper {
     String findSessionIdByBroadcastNo(Long broadcastNo);
     // 해당 스케줄이 방송중인지
     Long findLiveBroadcastNoByScheduleNo(Long scheduleNo);
+    // 방송 종료 시간 30분 지난방송 자동 종료처리
+    void expireOverdueBroadcasts();
 }

--- a/src/main/java/com/lawnroad/broadcast/live/service/BroadcastService.java
+++ b/src/main/java/com/lawnroad/broadcast/live/service/BroadcastService.java
@@ -1,6 +1,7 @@
 package com.lawnroad.broadcast.live.service;
 
 import com.lawnroad.broadcast.live.dto.*;
+import com.lawnroad.broadcast.live.model.BroadcastVo;
 
 import java.util.List;
 
@@ -17,4 +18,6 @@ public interface BroadcastService {
     void reportBroadcast(BroadcastReportRequestDto dto);
     // 방송 리스트
     List<BroadcastListDto> getLiveBroadcasts();
+    // 해당 스케줄이 방송중인지
+    Long findLiveBroadcastNoByScheduleNo(Long scheduleNo);
 }

--- a/src/main/java/com/lawnroad/broadcast/live/service/BroadcastService.java
+++ b/src/main/java/com/lawnroad/broadcast/live/service/BroadcastService.java
@@ -20,4 +20,6 @@ public interface BroadcastService {
     List<BroadcastListDto> getLiveBroadcasts();
     // 해당 스케줄이 방송중인지
     Long findLiveBroadcastNoByScheduleNo(Long scheduleNo);
+    // 방송종료시간 30분 지난방송 자동 종료처리
+    void expireOverdueBroadcasts();
 }

--- a/src/main/java/com/lawnroad/broadcast/live/service/BroadcastServiceImpl.java
+++ b/src/main/java/com/lawnroad/broadcast/live/service/BroadcastServiceImpl.java
@@ -157,4 +157,9 @@ public class BroadcastServiceImpl implements BroadcastService {
 
         return list;
     }
+
+    @Override
+    public Long findLiveBroadcastNoByScheduleNo(Long scheduleNo) {
+        return broadcastMapper.findLiveBroadcastNoByScheduleNo(scheduleNo);
+    }
 }

--- a/src/main/java/com/lawnroad/broadcast/live/service/BroadcastServiceImpl.java
+++ b/src/main/java/com/lawnroad/broadcast/live/service/BroadcastServiceImpl.java
@@ -162,4 +162,10 @@ public class BroadcastServiceImpl implements BroadcastService {
     public Long findLiveBroadcastNoByScheduleNo(Long scheduleNo) {
         return broadcastMapper.findLiveBroadcastNoByScheduleNo(scheduleNo);
     }
+
+    @Override
+    @Transactional
+    public void expireOverdueBroadcasts() {
+        broadcastMapper.expireOverdueBroadcasts();
+    }
 }

--- a/src/main/java/com/lawnroad/common/util/JwtTokenUtil.java
+++ b/src/main/java/com/lawnroad/common/util/JwtTokenUtil.java
@@ -29,7 +29,7 @@ public class  JwtTokenUtil {
                 .claim("role",role)
                 .claim("nickname", nickname)
                 .setIssuedAt(new Date())
-                .setExpiration(new Date(System.currentTimeMillis() + 1000 * 1))
+                .setExpiration(new Date(System.currentTimeMillis() + 1000 * 10))
                 .signWith(key, SignatureAlgorithm.HS256)
                 .compact();
 

--- a/src/main/resources/mapper/BroadcastMapper.xml
+++ b/src/main/resources/mapper/BroadcastMapper.xml
@@ -153,4 +153,15 @@
         WHERE schedule_no = #{scheduleNo}
         AND status = 'RECORD'
     </select>
+    <!-- 스케줄 end_time보다 30분이 지났으나 여전히 RECORD 인 컬럼 찾아서 DONE 처리 -->
+    <update id="expireOverdueBroadcasts">
+        UPDATE broadcast b
+        JOIN broadcast_schedule s ON b.schedule_no = s.no
+        SET
+        b.status = 'DONE',
+        b.end_time = TIMESTAMPADD(MINUTE, 30, s.end_time)
+        WHERE
+        b.status = 'RECORD'
+        AND TIMESTAMPADD(MINUTE, 30, s.end_time) &lt;= NOW()
+    </update>
 </mapper>

--- a/src/main/resources/mapper/BroadcastMapper.xml
+++ b/src/main/resources/mapper/BroadcastMapper.xml
@@ -146,4 +146,11 @@
     <select id="findSessionIdByBroadcastNo" resultType="String">
         SELECT session_id FROM broadcast WHERE no = #{broadcastNo}
     </select>
+    <!-- 스케줄no가 현재 방송중이면 가져오기 -->
+    <select id="findLiveBroadcastNoByScheduleNo" resultType="java.lang.Long">
+        SELECT no
+        FROM broadcast
+        WHERE schedule_no = #{scheduleNo}
+        AND status = 'RECORD'
+    </select>
 </mapper>


### PR DESCRIPTION
## 작업 내용

- [x] 방송 종료 자동처리 기능 추가 (라이브 방송, 방송 스케줄 클릭시 메서드 실행)
- [x] 클라이언트 방송 스케줄에서 현재 방송중인 방송이면 live 뱃지 추가, 방송시청으로 이동
- [x] 변호사가 시작시간이 임박한 스케줄 클릭 시 방송설정 페이지로 이동하도록 수정
- [x] 시작시간 10분 내인 방송에는 `방송 시작 가능` 뱃지 추가

## 전달사항

-

---

## PR 체크리스트

- [x] 커밋 메시지를 컨벤션에 맞게 작성했나요?
- [x] 로컬에서 테스트를 완료했나요?
- [x] 작업 전에 dev를 pull 받고 작업했나요?
- [x] push 하기 전에 dev를 작업 브랜치로 merge 받았나요?
- [x] dev 브랜치로 PR 올리는 중인지 다시 확인했나요?
- [x] PR 제목을 `feat: 작업내용 한줄 요약` 으로 올렸나요?