### PR TITLE
refactor: vod 페이지네이션 및 정렬추가, 라이브방송 리스트 무한 스크롤 추가

### DIFF
--- a/frontend/src/views/client/ClientBroadcastListView.vue
+++ b/frontend/src/views/client/ClientBroadcastListView.vue
@@ -54,7 +54,7 @@ onMounted(async () => {
 <template>
   <ClientFrame>
     <div class="container py-4">
-      <h2 class="fs-3 fw-bold mb-4">📺 현재 라이브 방송 중</h2>
+      <h2 class="fs-3 fw-bold text-primary mb-4">라이브 방송 목록</h2>
 
       <div class="row g-4">
         <div
@@ -129,6 +129,10 @@ onMounted(async () => {
             </div>
 
           </div>
+        </div>
+        <!-- 방송이 하나도 없을 때 표시 -->
+        <div v-if="broadcasts.length === 0" class="col-12 text-center py-5 text-muted fs-5 mt-16">
+          현재 진행중인 방송이 없습니다.
         </div>
       </div>
     </div>

--- a/frontend/src/views/client/ClientBroadcastsView.vue
+++ b/frontend/src/views/client/ClientBroadcastsView.vue
@@ -180,6 +180,36 @@ export default defineComponent({
       }
     };
 
+    const applyKeywordAlert = async () => {
+      const lawyerName = broadcastInfo.value.lawyerName
+
+      if (!lawyerName) {
+        alert('변호사 정보가 없습니다.')
+        return
+      }
+
+      const confirmed = confirm(`'${lawyerName}' 변호사의 방송 알림을 신청하시겠습니까?`)
+      if (!confirmed) return
+
+      try {
+        await makeApiRequest({
+          method: 'post',
+          url: '/api/client/keyword-alert/apply',
+          params: {
+            keyword: lawyerName
+          }
+        })
+        alert('🔔 알림 신청이 완료되었습니다!')
+      } catch (err) {
+        if (err.response?.status === 400) {
+          alert(`⚠️ ${err.response.data}`) // 예: 이미 신청함
+        } else {
+          alert('❌ 알림 신청 중 오류가 발생했습니다.')
+          console.error(err)
+        }
+      }
+    }
+
     const goToLawyerHomepage = () => {
       const userNo = broadcastInfo.value.userNo
       if (!userNo || userNo === 0) {
@@ -532,6 +562,7 @@ export default defineComponent({
       showPreQDropdown, preQuestions, isPreQLoading,
       goToLawyerHomepage,
       togglePreQDropdown, preQBtnRef, preQDropdownRef,selectedUserToShow,
+      applyKeywordAlert,
     };
   }
 });
@@ -613,7 +644,9 @@ export default defineComponent({
                 >
                   {{ broadcastInfo.lawyerName }} 변호사
                 </span>
-                <button class="btn btn-outline-primary btn-sm">🔔 알림신청</button>
+                <button class="btn btn-outline-primary btn-sm" @click="applyKeywordAlert">
+                  🔔 알림신청
+                </button>
               </div>
             </div>
 

--- a/frontend/src/views/client/ClientScheduleDetailView.vue
+++ b/frontend/src/views/client/ClientScheduleDetailView.vue
@@ -106,7 +106,7 @@ const goBackToCalendar = () => {
   <ClientFrame>
     <div class="w-100 min-vh-100 px-4 py-4">
       <div class="d-flex justify-content-between align-items-center mb-4">
-        <h2 class="fs-3 fw-bold text-primary mb-0">📅 {{ dateStr }} 방송 스케줄</h2>
+        <h2 class="fs-3 fw-bold text-primary mb-0">{{ dateStr }} 방송 스케줄</h2>
         <button class="btn btn-outline-secondary" @click="goBackToCalendar">← 달력으로 돌아가기</button>
       </div>
 

--- a/frontend/src/views/client/ClientScheduleView.vue
+++ b/frontend/src/views/client/ClientScheduleView.vue
@@ -143,7 +143,7 @@ onMounted(async () => {
 <template>
   <ClientFrame>
     <div class="w-100 vh-100 d-flex flex-column p-4">
-      <h2 class="fs-3 fw-bold mb-4 text-primary">📅 방송 스케줄</h2>
+      <h2 class="fs-3 fw-bold mb-4 text-primary">방송 스케줄</h2>
       <div class="flex-grow-1">
         <FullCalendar ref="calendarRef" :options="calendarOptions" />
       </div>

--- a/frontend/src/views/client/PublicVodListView.vue
+++ b/frontend/src/views/client/PublicVodListView.vue
@@ -1,11 +1,13 @@
 <script setup>
-import { onMounted, ref } from "vue";
+import {computed, onMounted, ref, watch} from "vue";
 import { useRouter } from "vue-router";
 import axios from "axios";
 import ClientFrame from "@/components/layout/client/ClientFrame.vue";
 
 const vodList = ref([]);
 const router = useRouter();
+const currentPage = ref(1);
+const totalPages = ref(1);
 
 const formatDuration = (seconds) => {
   const h = String(Math.floor(seconds / 3600)).padStart(2, "0");
@@ -16,8 +18,9 @@ const formatDuration = (seconds) => {
 
 const fetchVodList = async () => {
   try {
-    const res = await axios.get("/api/public/vod/list?page=1&size=12");
-    vodList.value = res.data.filter(v => v && v.vodNo);
+    const res = await axios.get(`/api/public/vod/list?page=${currentPage.value}&size=12`);
+    vodList.value = res.data.content;
+    totalPages.value = res.data.totalPages;
   } catch (err) {
     console.error("❌ VOD 목록 불러오기 실패:", err);
   }
@@ -32,7 +35,35 @@ const goToVod = async (vod) => {
   router.push(`/vod/${vod.broadcastNo}`); // broadcastNo 기준으로 이동
 };
 
-onMounted(fetchVodList);
+// Pagination group logic
+const pageGroup = computed(() => {
+  const groupSize = 5
+  const gIndex = Math.floor((currentPage.value - 1) / groupSize)
+  const start = gIndex * groupSize + 1
+  const end = Math.min(start + groupSize - 1, totalPages.value)
+  const pages = Array.from({ length: end - start + 1 }, (_, i) => start + i)
+  return {
+    pages,
+    hasPrevGroup: start > 1,
+    hasNextGroup: end < totalPages.value,
+    prevPage: start - 1,
+    nextPage: end + 1
+  }
+})
+
+function changePage(page) {
+  if (page >= 1 && page <= totalPages.value && page !== currentPage.value) {
+    currentPage.value = page
+  }
+}
+
+watch(currentPage, () => {
+  fetchVodList();
+});
+
+onMounted(() => {
+  fetchVodList();
+});
 </script>
 
 
@@ -106,6 +137,34 @@ onMounted(fetchVodList);
             </div>
           </div>
         </template>
+      </div>
+      <!-- 페이지네이션 -->
+      <div class="d-flex justify-content-center mt-4">
+        <ul class="pagination">
+          <!-- 이전 그룹 버튼 -->
+          <li class="page-item" :class="{ disabled: currentPage === 1 }">
+            <button class="page-link" @click="changePage(currentPage - 1)">Previous</button>
+          </li>
+          <li class="page-item" :class="{ disabled: !pageGroup.hasPrevGroup }">
+            <a class="page-link" @click="changePage(pageGroup.prevPage)">«</a>
+          </li>
+          <!-- 현재 그룹의 페이지 번호들 -->
+          <li
+              v-for="p in pageGroup.pages"
+              :key="p"
+              class="page-item"
+              :class="{ active: currentPage === p }"
+          >
+            <a class="page-link" @click="changePage(p)">{{ p }}</a>
+          </li>
+          <!-- 다음 그룹 버튼 -->
+          <li class="page-item" :class="{ disabled: !pageGroup.hasNextGroup }">
+            <a class="page-link" @click="changePage(pageGroup.nextPage)">»</a>
+          </li>
+          <li class="page-item" :class="{ disabled: currentPage === totalPages }">
+            <button class="page-link" @click="changePage(currentPage + 1)">Next</button>
+          </li>
+        </ul>
       </div>
     </div>
   </ClientFrame>

--- a/frontend/src/views/client/PublicVodListView.vue
+++ b/frontend/src/views/client/PublicVodListView.vue
@@ -8,6 +8,8 @@ const vodList = ref([]);
 const router = useRouter();
 const currentPage = ref(1);
 const totalPages = ref(1);
+// 정렬기준
+const orderType = ref("recent")
 
 const formatDuration = (seconds) => {
   const h = String(Math.floor(seconds / 3600)).padStart(2, "0");
@@ -18,7 +20,9 @@ const formatDuration = (seconds) => {
 
 const fetchVodList = async () => {
   try {
-    const res = await axios.get(`/api/public/vod/list?page=${currentPage.value}&size=12`);
+    const res = await axios.get(
+        `/api/public/vod/list?page=${currentPage.value}&size=12&orderType=${orderType.value}`
+    )
     vodList.value = res.data.content;
     totalPages.value = res.data.totalPages;
   } catch (err) {
@@ -34,6 +38,14 @@ const goToVod = async (vod) => {
   }
   router.push(`/vod/${vod.broadcastNo}`); // broadcastNo 기준으로 이동
 };
+
+const setOrder = (type) => {
+  if (orderType.value !== type) {
+    orderType.value = type
+    currentPage.value = 1 // 페이지 초기화
+    fetchVodList()
+  }
+}
 
 // Pagination group logic
 const pageGroup = computed(() => {
@@ -71,7 +83,23 @@ onMounted(() => {
   <ClientFrame>
     <div class="container py-4">
       <h2 class="fs-3 fw-bold text-primary mb-4">방송 다시보기</h2>
-
+      <!-- 정렬 버튼 -->
+      <div class="mb-3 d-flex gap-2">
+        <button
+            class="btn"
+            :class="orderType === 'recent' ? 'btn-primary' : 'btn-outline-primary'"
+            @click="setOrder('recent')"
+        >
+          최신순
+        </button>
+        <button
+            class="btn"
+            :class="orderType === 'popular' ? 'btn-primary' : 'btn-outline-primary'"
+            @click="setOrder('popular')"
+        >
+          인기순
+        </button>
+      </div>
       <div class="row g-4">
         <template v-for="vod in vodList" :key="vod.vodNo">
           <div class="col-12 col-sm-6 col-md-4 col-lg-3">

--- a/frontend/src/views/client/PublicVodView.vue
+++ b/frontend/src/views/client/PublicVodView.vue
@@ -4,6 +4,7 @@ import { useRoute } from "vue-router";
 import axios from "axios";
 import ClientFrame from "@/components/layout/client/ClientFrame.vue";
 import { useRouter } from 'vue-router'
+import {makeApiRequest} from "@/libs/axios-auth.js";
 
 // 라우터에서 방송 번호 가져오기
 const route = useRoute();
@@ -40,7 +41,35 @@ const goToLawyerHomepage = () => {
   router.push(`/lawyer/${userNo}/homepage`)
 }
 
+const applyKeywordAlert = async () => {
+  const lawyerName = vodInfo.value.lawyerName
 
+  if (!lawyerName) {
+    alert('변호사 정보가 없습니다.')
+    return
+  }
+
+  const confirmed = confirm(`'${lawyerName}' 변호사의 방송 알림을 신청하시겠습니까?`)
+  if (!confirmed) return
+
+  try {
+    await makeApiRequest({
+      method: 'post',
+      url: '/api/client/keyword-alert/apply',
+      params: {
+        keyword: lawyerName
+      }
+    })
+    alert('🔔 알림 신청이 완료되었습니다!')
+  } catch (err) {
+    if (err.response?.status === 400) {
+      alert(`⚠️ ${err.response.data}`) // 예: 이미 신청함
+    } else {
+      alert('❌ 알림 신청 중 오류가 발생했습니다.')
+      console.error(err)
+    }
+  }
+}
 
 
 // 컴포넌트 마운트 시 실행
@@ -178,7 +207,9 @@ const playChatsLikeLive = async () => {
             >
                   {{ vodInfo.lawyerName }} 변호사
                 </span>
-              <button class="btn btn-outline-primary btn-sm">🔔 알림신청</button>
+              <button class="btn btn-outline-primary btn-sm" @click="applyKeywordAlert">
+                🔔 알림신청
+              </button>
             </div>
           </div>
         </div>

--- a/frontend/src/views/lawyer/LawyerScheduleRegisterView.vue
+++ b/frontend/src/views/lawyer/LawyerScheduleRegisterView.vue
@@ -54,11 +54,26 @@ const newKeyword = ref('')
 
 const addKeyword = () => {
   const value = newKeyword.value.trim()
-  if (value && !keywords.value.includes(value)) {
-    keywords.value.push(value)
+  if (!value) return
+  if (value.length > 6) {
+    alert('⚠ 키워드는 6자 이하로 입력해야 합니다.')
+    return
   }
+
+  if (keywords.value.includes(value)) {
+    alert('⚠ 이미 추가된 키워드입니다.')
+    return
+  }
+
+  if (keywords.value.length >= 6) {
+    alert('⚠ 키워드는 최대 6개까지 등록할 수 있습니다.')
+    return
+  }
+
+  keywords.value.push(value)
   newKeyword.value = ''
 }
+
 
 const removeKeyword = (index) => {
   keywords.value.splice(index, 1)

--- a/frontend/src/views/lawyer/LawyerScheduleRegisterView.vue
+++ b/frontend/src/views/lawyer/LawyerScheduleRegisterView.vue
@@ -115,6 +115,12 @@ const formattedTimeRange = computed(() => {
   return `${formatDate(date.value)} ${startTime.value} ~ ${formatDate(endDate.value)} ${endTime.value}`
 })
 
+const handleConfirmSubmit = () => {
+  if (window.confirm("정말로 방송 스케줄을 등록하시겠습니까?")) {
+    submitSchedule();
+  }
+};
+
 const submitSchedule = async () => {
   try {
     const formData = new FormData()
@@ -125,7 +131,9 @@ const submitSchedule = async () => {
     formData.append('date', date.value)
     formData.append('startTime', `${date.value}T${startTime.value}:00`)
     formData.append('endTime', `${endDate.value}T${endTime.value}:00`)
-    formData.append('thumbnail', selectedFile.value)
+    if (selectedFile.value) {
+      formData.append('thumbnail', selectedFile.value)
+    }
     formData.append('keywords', JSON.stringify(keywords.value))
 
     const token = await getValidToken()
@@ -234,7 +242,7 @@ const goBack = () => {
 
         <div class="d-flex justify-content-between mt-4">
           <button class="btn btn-outline-secondary" @click="goBack">← 목록으로</button>
-          <button class="btn btn-primary" @click="submitSchedule">등록</button>
+          <button class="btn btn-primary" @click="handleConfirmSubmit">등록</button>
         </div>
       </div>
     </div>

--- a/src/main/java/com/lawnroad/LawNRoadApplication.java
+++ b/src/main/java/com/lawnroad/LawNRoadApplication.java
@@ -11,12 +11,17 @@ import org.springframework.security.crypto.password.PasswordEncoder;
 
 @EnableScheduling
 @SpringBootApplication
-@MapperScan({"com.lawnroad.broadcast.live.mapper","com.lawnroad.broadcast.chat.mapper","com.lawnroad.template.mapper", "com.lawnroad.account.mapper", "com.lawnroad.board.mapper", "com.lawnroad.mainsearch.mapper"})
-@MapperScan({"com.lawnroad.template.mapper", "com.lawnroad.account.mapper", "com.lawnroad.board.mapper", "com.lawnroad.mainsearch.mapper", "com.lawnroad.advertisement.mapper"})
-@MapperScan({"com.lawnroad.template.mapper", "com.lawnroad.account.mapper", "com.lawnroad.board.mapper", "com.lawnroad.mainsearch.mapper", "com.lawnroad.advertisement.mapper", "com.lawnroad.admin.mapper"})
-@MapperScan({"com.lawnroad.template.mapper", "com.lawnroad.account.mapper", "com.lawnroad.board.mapper",
-    "com.lawnroad.mainsearch.mapper", "com.lawnroad.advertisement.mapper", "com.lawnroad.admin.mapper",
-    "com.lawnroad.keyword.mapper"})
+@MapperScan({
+        "com.lawnroad.broadcast.live.mapper",
+        "com.lawnroad.broadcast.chat.mapper",
+        "com.lawnroad.template.mapper",
+        "com.lawnroad.account.mapper",
+        "com.lawnroad.board.mapper",
+        "com.lawnroad.mainsearch.mapper",
+        "com.lawnroad.advertisement.mapper",
+        "com.lawnroad.admin.mapper",
+        "com.lawnroad.keyword.mapper"
+})
 public class LawNRoadApplication {
     public static void main(String[] args) {
 

--- a/src/main/java/com/lawnroad/broadcast/live/controller/BroadcastClientController.java
+++ b/src/main/java/com/lawnroad/broadcast/live/controller/BroadcastClientController.java
@@ -59,10 +59,18 @@ public class BroadcastClientController {
     }
     // 라이브 목록조회
     @GetMapping("/live")
-    public ResponseEntity<List<BroadcastListDto>> getLiveBroadcasts() {
-        List<BroadcastListDto> liveList = broadcastService.getLiveBroadcasts();
-        return ResponseEntity.ok(liveList);
+    public ResponseEntity<BroadcastListResponseDto> getLiveBroadcasts(
+            @RequestParam(defaultValue = "1") int page,
+            @RequestParam(defaultValue = "9") int size
+    ) {
+        BroadcastListRequestDto requestDto = new BroadcastListRequestDto();
+        requestDto.setPage(page);
+        requestDto.setSize(size);
+
+        BroadcastListResponseDto response = broadcastService.getLiveBroadcasts(requestDto);
+        return ResponseEntity.ok(response);
     }
+
     // 라이브 중인지 확인
     @GetMapping("/live-check/{scheduleNo}")
     public ResponseEntity<Map<String, Object>> checkLiveBroadcast(@PathVariable Long scheduleNo) {

--- a/src/main/java/com/lawnroad/broadcast/live/controller/KeywordController.java
+++ b/src/main/java/com/lawnroad/broadcast/live/controller/KeywordController.java
@@ -1,0 +1,38 @@
+package com.lawnroad.broadcast.live.controller;
+
+import com.lawnroad.broadcast.live.service.KeywordService;
+import com.lawnroad.common.util.JwtTokenUtil;
+import io.jsonwebtoken.Claims;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/api/client/keyword-alert")
+@RequiredArgsConstructor
+public class KeywordController {
+
+    private final KeywordService keywordService;
+    private final JwtTokenUtil jwtTokenUtil;
+
+    @PostMapping("/apply")
+    public ResponseEntity<?> registerKeywordAlert(@RequestParam String keyword,
+                                                  @RequestHeader("Authorization") String authHeader) {
+        try {
+            // JWT 토큰에서 userNo 추출
+            String token = authHeader.replace("Bearer ", "");
+            Claims claims = jwtTokenUtil.parseToken(token);
+            Long userNo = claims.get("no", Long.class);
+
+            // 알림 등록 로직 실행
+            keywordService.registerKeywordAlert(userNo, keyword);
+            return ResponseEntity.ok("알림 신청 완료");
+
+        } catch (IllegalArgumentException e) {
+            return ResponseEntity.badRequest().body(e.getMessage());
+
+        } catch (Exception e) {
+            return ResponseEntity.status(500).body("서버 오류로 알림 신청에 실패했습니다.");
+        }
+    }
+}

--- a/src/main/java/com/lawnroad/broadcast/live/controller/ScheduleLawyerController.java
+++ b/src/main/java/com/lawnroad/broadcast/live/controller/ScheduleLawyerController.java
@@ -39,16 +39,16 @@ public class ScheduleLawyerController {
             @RequestParam("date") String date,
             @RequestParam("startTime") String startTime,
             @RequestParam("endTime") String endTime,
-            @RequestParam("thumbnail") MultipartFile thumbnail,
+            @RequestParam(value = "thumbnail", required = false) MultipartFile thumbnail,
             @RequestParam(value = "keywords", required = false) String keywordsJson
     ) {
         String token = authHeader.replace("Bearer ", "");
         Claims claims = jwtTokenUtil.parseToken(token);
         Long userNo = claims.get("no", Long.class);
 
-        String path = ncpObjectStorageUtil.save(thumbnail, "uploads/lawyers/" + userNo + "/thumbnail", null);
-        if (path == null || path.isEmpty()) {
-            throw new IllegalArgumentException("썸네일 파일 경로가 없습니다.");
+        String path = null;
+        if (thumbnail != null && !thumbnail.isEmpty()) {
+            path = ncpObjectStorageUtil.save(thumbnail, "uploads/lawyers/" + userNo + "/thumbnail", null);
         }
 
         // keywords JSON을 List<String>으로 변환

--- a/src/main/java/com/lawnroad/broadcast/live/controller/VodPublicController.java
+++ b/src/main/java/com/lawnroad/broadcast/live/controller/VodPublicController.java
@@ -21,11 +21,13 @@ public class VodPublicController {
     @GetMapping("/list")
     public ResponseEntity<VodListResponseDto> getVodList(
             @RequestParam(defaultValue = "1") int page,
-            @RequestParam(defaultValue = "12") int size
+            @RequestParam(defaultValue = "12") int size,
+            @RequestParam(defaultValue = "recent") String orderType
     ) {
         VodListRequestDto requestDto = new VodListRequestDto();
         requestDto.setPage(page);
         requestDto.setSize(size);
+        requestDto.setOrderType(orderType);
 
         VodListResponseDto response = vodService.getPagedVodList(requestDto);
         return ResponseEntity.ok(response);

--- a/src/main/java/com/lawnroad/broadcast/live/controller/VodPublicController.java
+++ b/src/main/java/com/lawnroad/broadcast/live/controller/VodPublicController.java
@@ -3,6 +3,7 @@ package com.lawnroad.broadcast.live.controller;
 import com.lawnroad.broadcast.live.dto.VodDetailDto;
 import com.lawnroad.broadcast.live.dto.VodListDto;
 import com.lawnroad.broadcast.live.dto.VodListRequestDto;
+import com.lawnroad.broadcast.live.dto.VodListResponseDto;
 import com.lawnroad.broadcast.live.service.VodService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
@@ -18,7 +19,7 @@ public class VodPublicController {
     private final VodService vodService;
 
     @GetMapping("/list")
-    public ResponseEntity<List<VodListDto>> getVodList(
+    public ResponseEntity<VodListResponseDto> getVodList(
             @RequestParam(defaultValue = "1") int page,
             @RequestParam(defaultValue = "12") int size
     ) {
@@ -26,9 +27,8 @@ public class VodPublicController {
         requestDto.setPage(page);
         requestDto.setSize(size);
 
-        List<VodListDto> vodList = vodService.getPublicVodList(requestDto);
-        System.out.println(vodList);
-        return ResponseEntity.ok(vodList);
+        VodListResponseDto response = vodService.getPagedVodList(requestDto);
+        return ResponseEntity.ok(response);
     }
 
     // 조회수 증가

--- a/src/main/java/com/lawnroad/broadcast/live/controller/VodPublicController.java
+++ b/src/main/java/com/lawnroad/broadcast/live/controller/VodPublicController.java
@@ -22,12 +22,14 @@ public class VodPublicController {
     public ResponseEntity<VodListResponseDto> getVodList(
             @RequestParam(defaultValue = "1") int page,
             @RequestParam(defaultValue = "12") int size,
-            @RequestParam(defaultValue = "recent") String orderType
+            @RequestParam(defaultValue = "recent") String sort,
+            @RequestParam(required = false) Long categoryNo
     ) {
         VodListRequestDto requestDto = new VodListRequestDto();
         requestDto.setPage(page);
         requestDto.setSize(size);
-        requestDto.setOrderType(orderType);
+        requestDto.setSort(sort);
+        requestDto.setCategoryNo(categoryNo);
 
         VodListResponseDto response = vodService.getPagedVodList(requestDto);
         return ResponseEntity.ok(response);

--- a/src/main/java/com/lawnroad/broadcast/live/dto/BroadcastListRequestDto.java
+++ b/src/main/java/com/lawnroad/broadcast/live/dto/BroadcastListRequestDto.java
@@ -1,0 +1,13 @@
+package com.lawnroad.broadcast.live.dto;
+
+import lombok.Data;
+
+@Data
+public class BroadcastListRequestDto {
+    private int page = 1;   // 기본값: 1페이지
+    private int size = 9;   // 기본값: 9개씩 (3줄)
+
+    public int getOffset() {
+        return (page - 1) * size;
+    }
+}

--- a/src/main/java/com/lawnroad/broadcast/live/dto/BroadcastListResponseDto.java
+++ b/src/main/java/com/lawnroad/broadcast/live/dto/BroadcastListResponseDto.java
@@ -1,0 +1,13 @@
+package com.lawnroad.broadcast.live.dto;
+
+import lombok.Data;
+
+import java.util.List;
+
+@Data
+public class BroadcastListResponseDto {
+    private List<BroadcastListDto> content;
+    private long totalElements;
+    private int totalPages;
+    private int currentPage;
+}

--- a/src/main/java/com/lawnroad/broadcast/live/dto/KeywordAlertRequestDto.java
+++ b/src/main/java/com/lawnroad/broadcast/live/dto/KeywordAlertRequestDto.java
@@ -1,0 +1,8 @@
+package com.lawnroad.broadcast.live.dto;
+
+import lombok.Data;
+
+@Data
+public class KeywordAlertRequestDto {
+    private String keyword; //변호사 이름
+}

--- a/src/main/java/com/lawnroad/broadcast/live/dto/KeywordAlertResponseDto.java
+++ b/src/main/java/com/lawnroad/broadcast/live/dto/KeywordAlertResponseDto.java
@@ -1,0 +1,12 @@
+package com.lawnroad.broadcast.live.dto;
+
+import lombok.Data;
+
+import java.time.LocalDateTime;
+
+@Data
+public class KeywordAlertResponseDto {
+    private Long no;
+    private String keyword;
+    private LocalDateTime createdAt;
+}

--- a/src/main/java/com/lawnroad/broadcast/live/dto/VodListRequestDto.java
+++ b/src/main/java/com/lawnroad/broadcast/live/dto/VodListRequestDto.java
@@ -6,7 +6,8 @@ import lombok.Data;
 public class VodListRequestDto {
     private int page = 1;
     private int size = 12;
-    private String orderType = "recent"; // "recent" or "popular"
+    private String sort = "recent"; // "recent" or "popular"
+    private Long categoryNo; // 선택된 카테고리 번호 (nullable)
 
     public int getOffset() {
         return (page - 1) * size;

--- a/src/main/java/com/lawnroad/broadcast/live/dto/VodListRequestDto.java
+++ b/src/main/java/com/lawnroad/broadcast/live/dto/VodListRequestDto.java
@@ -6,6 +6,7 @@ import lombok.Data;
 public class VodListRequestDto {
     private int page = 1;
     private int size = 12;
+    private String orderType = "recent"; // "recent" or "popular"
 
     public int getOffset() {
         return (page - 1) * size;

--- a/src/main/java/com/lawnroad/broadcast/live/dto/VodListResponseDto.java
+++ b/src/main/java/com/lawnroad/broadcast/live/dto/VodListResponseDto.java
@@ -1,0 +1,13 @@
+package com.lawnroad.broadcast.live.dto;
+
+import lombok.Data;
+
+import java.util.List;
+
+@Data
+public class VodListResponseDto {
+    private List<VodListDto> content;
+    private int totalPages;
+    private long totalElements;
+    private int currentPage;
+}

--- a/src/main/java/com/lawnroad/broadcast/live/mapper/BroadcastMapper.java
+++ b/src/main/java/com/lawnroad/broadcast/live/mapper/BroadcastMapper.java
@@ -26,7 +26,10 @@ public interface BroadcastMapper {
     List<ReportReasonDto> findAllReportReasons();
 
     // 방송 리스트
-    List<BroadcastListDto> selectLiveBroadcasts();
+    List<BroadcastListDto> selectLiveBroadcastsPaged(@Param("offset") int offset,
+                                                     @Param("size") int size);
+    // 라이브 중인 방송 개수
+    long countLiveBroadcasts();
     // 세션ID 가져오기
     String findSessionIdByBroadcastNo(Long broadcastNo);
     // 해당 스케줄이 방송중인지

--- a/src/main/java/com/lawnroad/broadcast/live/mapper/KeywordMapper.java
+++ b/src/main/java/com/lawnroad/broadcast/live/mapper/KeywordMapper.java
@@ -8,4 +8,10 @@ import org.apache.ibatis.annotations.Param;
 public interface KeywordMapper {
     void insertKeyword(KeywordVo keywordVo);
     void deleteByScheduleNo(@Param("scheduleNo") Long scheduleNo);
+
+    // 키워드 알림 등록
+    int insertKeywordAlert(@Param("userNo") Long userNo, @Param("keyword") String keyword);
+
+    // 키워드 알림 중복 여부 확인
+    boolean existsByUserNoAndKeyword(@Param("userNo") Long userNo, @Param("keyword") String keyword);
 }

--- a/src/main/java/com/lawnroad/broadcast/live/mapper/VodMapper.java
+++ b/src/main/java/com/lawnroad/broadcast/live/mapper/VodMapper.java
@@ -16,12 +16,12 @@ public interface VodMapper {
                                       @Param("sort") String sort,
                                       @Param("categoryNo") Long categoryNo);
     void increaseViewCount(Long vodNo);
-
     // vod 상세
     VodDetailDto findVodDetailByBroadcastNo(Long broadcastNo);
-
     // 페이지네이션 관련
     long countVodByCondition(@Param("categoryNo") Long categoryNo);
-    String selectNameByUserNo(Long userNo);
 
+
+
+    String selectNameByUserNo(Long userNo);
 }

--- a/src/main/java/com/lawnroad/broadcast/live/mapper/VodMapper.java
+++ b/src/main/java/com/lawnroad/broadcast/live/mapper/VodMapper.java
@@ -16,4 +16,7 @@ public interface VodMapper {
 
     // vod 상세
     VodDetailDto findVodDetailByBroadcastNo(Long broadcastNo);
+
+    // 페이지네이션 관련
+    long countAllVod();
 }

--- a/src/main/java/com/lawnroad/broadcast/live/mapper/VodMapper.java
+++ b/src/main/java/com/lawnroad/broadcast/live/mapper/VodMapper.java
@@ -13,12 +13,13 @@ public interface VodMapper {
     void insertVod(BroadcastVodVo vod);
     List<VodListDto> findVodListPaged(@Param("offset") int offset,
                                       @Param("size") int size,
-                                      @Param("orderType") String orderType);
+                                      @Param("sort") String sort,
+                                      @Param("categoryNo") Long categoryNo);
     void increaseViewCount(Long vodNo);
 
     // vod 상세
     VodDetailDto findVodDetailByBroadcastNo(Long broadcastNo);
 
     // 페이지네이션 관련
-    long countAllVod();
+    long countVodByCondition(@Param("categoryNo") Long categoryNo);
 }

--- a/src/main/java/com/lawnroad/broadcast/live/mapper/VodMapper.java
+++ b/src/main/java/com/lawnroad/broadcast/live/mapper/VodMapper.java
@@ -11,7 +11,9 @@ import java.util.List;
 @Mapper
 public interface VodMapper {
     void insertVod(BroadcastVodVo vod);
-    List<VodListDto> findVodListPaged(@Param("offset") int offset, @Param("size") int size);
+    List<VodListDto> findVodListPaged(@Param("offset") int offset,
+                                      @Param("size") int size,
+                                      @Param("orderType") String orderType);
     void increaseViewCount(Long vodNo);
 
     // vod 상세

--- a/src/main/java/com/lawnroad/broadcast/live/service/BroadcastService.java
+++ b/src/main/java/com/lawnroad/broadcast/live/service/BroadcastService.java
@@ -17,7 +17,7 @@ public interface BroadcastService {
     //방송 신고
     void reportBroadcast(BroadcastReportRequestDto dto);
     // 방송 리스트
-    List<BroadcastListDto> getLiveBroadcasts();
+    BroadcastListResponseDto getLiveBroadcasts(BroadcastListRequestDto requestDto);
     // 해당 스케줄이 방송중인지
     Long findLiveBroadcastNoByScheduleNo(Long scheduleNo);
     // 방송종료시간 30분 지난방송 자동 종료처리

--- a/src/main/java/com/lawnroad/broadcast/live/service/KeywordService.java
+++ b/src/main/java/com/lawnroad/broadcast/live/service/KeywordService.java
@@ -4,4 +4,5 @@ import com.lawnroad.broadcast.live.model.KeywordVo;
 
 public interface KeywordService {
     void insertKeyword(KeywordVo keywordVo);
+    void registerKeywordAlert(Long userNo, String keyword);
 }

--- a/src/main/java/com/lawnroad/broadcast/live/service/KeywordServiceImpl.java
+++ b/src/main/java/com/lawnroad/broadcast/live/service/KeywordServiceImpl.java
@@ -15,4 +15,17 @@ public class KeywordServiceImpl implements KeywordService {
     public void insertKeyword(KeywordVo keywordVo) {
         keywordMapper.insertKeyword(keywordVo);
     }
+
+    @Override
+    public void registerKeywordAlert(Long userNo, String keyword) {
+        boolean exists = keywordMapper.existsByUserNoAndKeyword(userNo, keyword);
+        if (exists) {
+            throw new IllegalArgumentException("이미 완료된 알림신청입니다.");
+        }
+
+        int result = keywordMapper.insertKeywordAlert(userNo, keyword);
+        if (result == 0) {
+            throw new RuntimeException("알림 신청에 실패했습니다.");
+        }
+    }
 }

--- a/src/main/java/com/lawnroad/broadcast/live/service/VodService.java
+++ b/src/main/java/com/lawnroad/broadcast/live/service/VodService.java
@@ -3,13 +3,14 @@ package com.lawnroad.broadcast.live.service;
 import com.lawnroad.broadcast.live.dto.VodDetailDto;
 import com.lawnroad.broadcast.live.dto.VodListDto;
 import com.lawnroad.broadcast.live.dto.VodListRequestDto;
+import com.lawnroad.broadcast.live.dto.VodListResponseDto;
 import org.springframework.web.multipart.MultipartFile;
 
 import java.util.List;
 
 public interface VodService {
     void saveVodFile(Long broadcastNo, MultipartFile file, Integer duration, Long userNo) throws Exception;
-    List<VodListDto> getPublicVodList(VodListRequestDto requestDto);
+    VodListResponseDto getPagedVodList(VodListRequestDto requestDto);
     void increaseViewCount(Long vodNo);
 
     // vod 상세

--- a/src/main/java/com/lawnroad/broadcast/live/service/VodServiceImpl.java
+++ b/src/main/java/com/lawnroad/broadcast/live/service/VodServiceImpl.java
@@ -49,10 +49,13 @@ public class VodServiceImpl implements VodService {
         List<VodListDto> list = vodMapper.findVodListPaged(
                 requestDto.getOffset(),
                 requestDto.getSize(),
-                requestDto.getOrderType()
+                requestDto.getSort(),
+                requestDto.getCategoryNo()
         );
 
-        long totalCount = vodMapper.countAllVod();
+        long totalCount = vodMapper.countVodByCondition(
+                requestDto.getCategoryNo() // 카테고리 필터 추가
+        );
 
         int totalPages = (int) Math.ceil((double) totalCount / requestDto.getSize());
 

--- a/src/main/java/com/lawnroad/broadcast/live/service/VodServiceImpl.java
+++ b/src/main/java/com/lawnroad/broadcast/live/service/VodServiceImpl.java
@@ -46,7 +46,12 @@ public class VodServiceImpl implements VodService {
 
     @Override
     public VodListResponseDto getPagedVodList(VodListRequestDto requestDto) {
-        List<VodListDto> list = vodMapper.findVodListPaged(requestDto.getOffset(), requestDto.getSize());
+        List<VodListDto> list = vodMapper.findVodListPaged(
+                requestDto.getOffset(),
+                requestDto.getSize(),
+                requestDto.getOrderType()
+        );
+
         long totalCount = vodMapper.countAllVod();
 
         int totalPages = (int) Math.ceil((double) totalCount / requestDto.getSize());

--- a/src/main/java/com/lawnroad/broadcast/live/service/VodServiceImpl.java
+++ b/src/main/java/com/lawnroad/broadcast/live/service/VodServiceImpl.java
@@ -3,6 +3,7 @@ package com.lawnroad.broadcast.live.service;
 import com.lawnroad.broadcast.live.dto.VodDetailDto;
 import com.lawnroad.broadcast.live.dto.VodListDto;
 import com.lawnroad.broadcast.live.dto.VodListRequestDto;
+import com.lawnroad.broadcast.live.dto.VodListResponseDto;
 import com.lawnroad.broadcast.live.mapper.VodMapper;
 import com.lawnroad.broadcast.live.model.BroadcastVodVo;
 import com.lawnroad.common.util.FileStorageUtil;
@@ -44,8 +45,19 @@ public class VodServiceImpl implements VodService {
     }
 
     @Override
-    public List<VodListDto> getPublicVodList(VodListRequestDto requestDto) {
-        return vodMapper.findVodListPaged(requestDto.getOffset(), requestDto.getSize());
+    public VodListResponseDto getPagedVodList(VodListRequestDto requestDto) {
+        List<VodListDto> list = vodMapper.findVodListPaged(requestDto.getOffset(), requestDto.getSize());
+        long totalCount = vodMapper.countAllVod();
+
+        int totalPages = (int) Math.ceil((double) totalCount / requestDto.getSize());
+
+        VodListResponseDto response = new VodListResponseDto();
+        response.setContent(list);
+        response.setTotalElements(totalCount);
+        response.setTotalPages(totalPages);
+        response.setCurrentPage(requestDto.getPage());
+
+        return response;
     }
 
     @Override

--- a/src/main/resources/mapper/BroadcastMapper.xml
+++ b/src/main/resources/mapper/BroadcastMapper.xml
@@ -127,7 +127,7 @@
         label ASC
     </select>
     <!-- 방송 목록 조회 -->
-    <select id="selectLiveBroadcasts" resultMap="BroadcastListMap">
+    <select id="selectLiveBroadcastsPaged" resultMap="BroadcastListMap">
         SELECT
         b.no AS broadcast_no,
         b.start_time,
@@ -144,6 +144,13 @@
         JOIN category c ON s.category_no = c.no
         WHERE b.status = 'RECORD'
         ORDER BY b.start_time DESC
+        LIMIT #{size} OFFSET #{offset}
+    </select>
+    <!--  방송 갯수 조회  -->
+    <select id="countLiveBroadcasts" resultType="long">
+        SELECT COUNT(*)
+        FROM broadcast b
+        WHERE b.status = 'RECORD'
     </select>
     <!-- 세션ID 가져오기 -->
     <select id="findSessionIdByBroadcastNo" resultType="String">

--- a/src/main/resources/mapper/KeywordMapper.xml
+++ b/src/main/resources/mapper/KeywordMapper.xml
@@ -14,4 +14,16 @@
         DELETE FROM keyword WHERE schedule_no = #{scheduleNo}
     </delete>
 
+    <insert id="insertKeywordAlert">
+        INSERT INTO keyword_alert (user_no, keyword)
+        VALUES (#{userNo}, #{keyword})
+    </insert>
+
+    <select id="existsByUserNoAndKeyword" resultType="boolean">
+        SELECT EXISTS (
+        SELECT 1 FROM keyword_alert
+        WHERE user_no = #{userNo} AND keyword = #{keyword}
+        )
+    </select>
+
 </mapper>

--- a/src/main/resources/mapper/VodMapper.xml
+++ b/src/main/resources/mapper/VodMapper.xml
@@ -132,12 +132,12 @@
         </if>
     </select>
 
-        <!-- 채팅 변호사 이름 가져오기-->
-        <select id="selectNameByUserNo" parameterType="long" resultType="string">
-            SELECT name
-            FROM lawyer
-            WHERE no = #{userNo}
-        </select>
+    <!-- 채팅 변호사 이름 가져오기-->
+    <select id="selectNameByUserNo" parameterType="long" resultType="string">
+        SELECT name
+        FROM lawyer
+        WHERE no = #{userNo}
+    </select>
 
 
 </mapper>

--- a/src/main/resources/mapper/VodMapper.xml
+++ b/src/main/resources/mapper/VodMapper.xml
@@ -74,7 +74,14 @@
         JOIN category c ON bs.category_no = c.no
         JOIN lawyer l ON b.user_no = l.no
         WHERE v.status = 0
-        ORDER BY v.created_at DESC
+        <choose>
+            <when test="orderType == 'popular'">
+                ORDER BY v.view_count DESC
+            </when>
+            <otherwise>
+                ORDER BY v.created_at DESC
+            </otherwise>
+        </choose>
         LIMIT #{size} OFFSET #{offset}
     </select>
 

--- a/src/main/resources/mapper/VodMapper.xml
+++ b/src/main/resources/mapper/VodMapper.xml
@@ -74,8 +74,11 @@
         JOIN category c ON bs.category_no = c.no
         JOIN lawyer l ON b.user_no = l.no
         WHERE v.status = 0
+        <if test="categoryNo != null">
+            AND c.no = #{categoryNo}
+        </if>
         <choose>
-            <when test="orderType == 'popular'">
+            <when test="sort == 'popular'">
                 ORDER BY v.view_count DESC
             </when>
             <otherwise>
@@ -119,8 +122,14 @@
         WHERE v.status = 0 AND v.broadcast_no = #{broadcastNo}
     </select>
 
-    <select id="countAllVod" resultType="long">
-        SELECT COUNT(*) FROM broadcast_vod WHERE status = 0
+    <select id="countVodByCondition" resultType="long">
+        SELECT COUNT(*) FROM broadcast_vod v
+        JOIN broadcast b ON v.broadcast_no = b.no
+        JOIN broadcast_schedule bs ON b.schedule_no = bs.no
+        WHERE v.status = 0
+        <if test="categoryNo != null">
+            AND bs.category_no = #{categoryNo}
+        </if>
     </select>
 
 </mapper>

--- a/src/main/resources/mapper/VodMapper.xml
+++ b/src/main/resources/mapper/VodMapper.xml
@@ -93,12 +93,12 @@
         v.duration,
         v.view_count,
         v.created_at,
+        b.start_time,
+        b.end_time,
         bs.no AS schedule_no,
         bs.name AS title,
         bs.content,
         bs.date,
-        bs.start_time,
-        bs.end_time,
         bs.thumbnail_path,
         c.name AS category_name,
         l.no AS lawyer_no,
@@ -112,5 +112,8 @@
         WHERE v.status = 0 AND v.broadcast_no = #{broadcastNo}
     </select>
 
+    <select id="countAllVod" resultType="long">
+        SELECT COUNT(*) FROM broadcast_vod WHERE status = 0
+    </select>
 
 </mapper>


### PR DESCRIPTION
## 작업 내용

- [x] 스케줄 등록 시 썸네일 필수입력 안해도 되도록 변경
- [x] 키워드 최대 6개 까지 등록하도록 수정, 각 키워드 글자 수도 6자 이내로 제한
- [x] vod 리스트 페이지네이션 추가
- [x] vod 리스트 최신순/인기순 정렬추가
- [x] vod 리스트 카테고리별 정렬 추가
- [x] 방송리스트에서 방송이 하나도 없을때, 출력되는 메시지 설정
- [x] 방송 리스트에서 무한 스크롤 기능 적용
- [x] 라이브 방송 및 vod 에서 변호사 옆 알림신청 클릭 시 변호사 이름으로 키워드 알림 등록

## 전달사항

-

---

## PR 체크리스트

- [x] 커밋 메시지를 컨벤션에 맞게 작성했나요?
- [x] 로컬에서 테스트를 완료했나요?
- [x] 작업 전에 dev를 pull 받고 작업했나요?
- [x] push 하기 전에 dev를 작업 브랜치로 merge 받았나요?
- [x] dev 브랜치로 PR 올리는 중인지 다시 확인했나요?
- [x] PR 제목을 `feat: 작업내용 한줄 요약` 으로 올렸나요?